### PR TITLE
master to main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(FETCHCONTENT_QUIET OFF)
 FetchContent_Declare(
   wabt
   GIT_REPOSITORY https://github.com/WebAssembly/wabt
-  GIT_TAG        master
+  GIT_TAG        main
   )
 set(BUILD_TESTS off)
 set(BUILD_LIBWASM off)


### PR DESCRIPTION
WASM changed the name of their default branch.